### PR TITLE
feat: search links by keyword (builds on clipboard PR)

### DIFF
--- a/addon/globalPlugins/favoriteLinks/__init__.py
+++ b/addon/globalPlugins/favoriteLinks/__init__.py
@@ -187,7 +187,11 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		"""
 		def open_dialog():
 			from .linkManager import LinkManager as _LM
-			lm = _LM()
+			try:
+				lm = _LM()
+			except Exception as e:
+				log.error("Error loading link manager for search: %s", e)
+				lm = _LM.empty()
 			if not lm.data:
 				# Translators: Spoken when there are no saved links to search.
 				ui.message(_("No categories found. Please add some links first."))

--- a/addon/globalPlugins/favoriteLinks/__init__.py
+++ b/addon/globalPlugins/favoriteLinks/__init__.py
@@ -193,7 +193,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			except Exception as e:
 				log.error("Error loading link manager for search: %s", e)
 				load_failed = True
-				lm = _LM.empty()
 			if load_failed:
 				# Translators: Spoken when the link data file cannot be loaded for search.
 				ui.message(_("Failed to load links. Please check the file."))

--- a/addon/globalPlugins/favoriteLinks/__init__.py
+++ b/addon/globalPlugins/favoriteLinks/__init__.py
@@ -214,8 +214,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				dlg.CentreOnScreen()
 				dlg.ShowModal()
 			finally:
-				gui.mainFrame.postPopup()
 				dlg.Destroy()
+				gui.mainFrame.postPopup()
 		wx.CallAfter(open_dialog)
 
 	def terminate(self):

--- a/addon/globalPlugins/favoriteLinks/__init__.py
+++ b/addon/globalPlugins/favoriteLinks/__init__.py
@@ -185,8 +185,17 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		Args:
 			gesture (kb): Triggered by NVDA+Shift+G.
 		"""
-		from .linkManager import LinkManager as _LM
-		wx.CallAfter(SearchLinks, mainFrame, _LM())
+		def open_dialog():
+			from .linkManager import LinkManager as _LM
+			dlg = SearchLinks(mainFrame, _LM())
+			if not dlg.GetHandle():
+				return
+			gui.mainFrame.prePopup()
+			dlg.CentreOnScreen()
+			dlg.ShowModal()
+			gui.mainFrame.postPopup()
+			dlg.Destroy()
+		wx.CallAfter(open_dialog)
 
 	def terminate(self):
 		"""

--- a/addon/globalPlugins/favoriteLinks/__init__.py
+++ b/addon/globalPlugins/favoriteLinks/__init__.py
@@ -24,7 +24,7 @@ from logHandler import log
 from scriptHandler import script
 
 from .configPanel import FavoriteLinksSettingsPanel
-from .main import FavoriteLinks 
+from .main import FavoriteLinks
 from .searchLinks import SearchLinks
 from .varsConfig import ADDON_SUMMARY, initConfiguration
 

--- a/addon/globalPlugins/favoriteLinks/__init__.py
+++ b/addon/globalPlugins/favoriteLinks/__init__.py
@@ -198,8 +198,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				ui.message(_("Failed to load links. Please check the file."))
 				return
 			if not lm.data:
-				# Translators: Spoken when there are no saved links to search.
-				ui.message(_("No categories found. Please add some links first."))
+				# Translators: Spoken when there are no saved links to search, or when
+				# the links file was corrupt and was automatically reset.
+				ui.message(_("No saved links found. If you had links before, the links file may have been corrupt and was reset. Please add links to begin."))
 				return
 			try:
 				dlg = SearchLinks(mainFrame, lm)

--- a/addon/globalPlugins/favoriteLinks/__init__.py
+++ b/addon/globalPlugins/favoriteLinks/__init__.py
@@ -187,14 +187,19 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		"""
 		def open_dialog():
 			from .linkManager import LinkManager as _LM
-			dlg = SearchLinks(mainFrame, _LM())
-			if not dlg.GetHandle():
+			lm = _LM()
+			if not lm.data:
+				# Translators: Spoken when there are no saved links to search.
+				ui.message(_("No categories found. Please add some links first."))
 				return
+			dlg = SearchLinks(mainFrame, lm)
 			gui.mainFrame.prePopup()
-			dlg.CentreOnScreen()
-			dlg.ShowModal()
-			gui.mainFrame.postPopup()
-			dlg.Destroy()
+			try:
+				dlg.CentreOnScreen()
+				dlg.ShowModal()
+			finally:
+				gui.mainFrame.postPopup()
+				dlg.Destroy()
 		wx.CallAfter(open_dialog)
 
 	def terminate(self):

--- a/addon/globalPlugins/favoriteLinks/__init__.py
+++ b/addon/globalPlugins/favoriteLinks/__init__.py
@@ -187,16 +187,28 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		"""
 		def open_dialog():
 			from .linkManager import LinkManager as _LM
+			load_failed = False
 			try:
 				lm = _LM()
 			except Exception as e:
 				log.error("Error loading link manager for search: %s", e)
+				load_failed = True
 				lm = _LM.empty()
+			if load_failed:
+				# Translators: Spoken when the link data file cannot be loaded for search.
+				ui.message(_("Failed to load links. Please check the file."))
+				return
 			if not lm.data:
 				# Translators: Spoken when there are no saved links to search.
 				ui.message(_("No categories found. Please add some links first."))
 				return
-			dlg = SearchLinks(mainFrame, lm)
+			try:
+				dlg = SearchLinks(mainFrame, lm)
+			except Exception as e:
+				log.error("Error creating search dialog: %s", e)
+				# Translators: Spoken when the search dialog cannot be opened.
+				ui.message(_("Unable to open the search dialog."))
+				return
 			gui.mainFrame.prePopup()
 			try:
 				dlg.CentreOnScreen()

--- a/addon/globalPlugins/favoriteLinks/__init__.py
+++ b/addon/globalPlugins/favoriteLinks/__init__.py
@@ -25,6 +25,7 @@ from scriptHandler import script
 
 from .configPanel import FavoriteLinksSettingsPanel
 from .main import FavoriteLinks 
+from .searchLinks import SearchLinks
 from .varsConfig import ADDON_SUMMARY, initConfiguration
 
 # Initialize translation support
@@ -166,6 +167,26 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		else:
 			# Translators: The user is not in a browser.
 			ui.message(_("No browser window found."))
+
+	@script(
+		gesture="kb:NVDA+shift+g",
+		# Translators: Description shown in NVDA input gestures for opening the search links dialog.
+		description=_("Search saved links by name or URL."),
+		category=ADDON_SUMMARY
+	)
+	def script_searchLinks(self, gesture):
+		"""
+		Opens the Search Links dialog, which lets the user search for saved
+		links by their display name or URL within a selected category.
+
+		Inspired by the Link Manager add-on by Abdallah Hader:
+		https://github.com/abdallah-hader/linkManager
+
+		Args:
+			gesture (kb): Triggered by NVDA+Shift+G.
+		"""
+		from .linkManager import LinkManager as _LM
+		wx.CallAfter(SearchLinks, mainFrame, _LM())
 
 	def terminate(self):
 		"""

--- a/addon/globalPlugins/favoriteLinks/linkManager.py
+++ b/addon/globalPlugins/favoriteLinks/linkManager.py
@@ -79,6 +79,7 @@ class LinkManager:
 		except JSONDecodeError:
 			self.data = {}
 			log.warning("JSON file is corrupt, loading empty data: %s", self.json_file_path)
+			self.save_links()
 			raise JSONDecodeError(_("Error decoding the JSON. Check the file content."), doc='', pos=0)
 
 	def save_links(self):

--- a/addon/globalPlugins/favoriteLinks/linkManager.py
+++ b/addon/globalPlugins/favoriteLinks/linkManager.py
@@ -76,17 +76,10 @@ class LinkManager:
 		except FileNotFoundError:
 			self.data = {}
 			self.save_links()
-		except JSONDecodeError as e:
+		except JSONDecodeError:
 			self.data = {}
-			log.error("JSON file is corrupt, resetting to empty: %s", self.json_file_path)
-			try:
-				backup = self.json_file_path + ".corrupt"
-				os.replace(self.json_file_path, backup)
-				log.info("Corrupt JSON backed up to: %s", backup)
-			except OSError as backup_err:
-				log.warning("Could not back up corrupt JSON: %s", backup_err)
-			self.save_links()
-			raise RuntimeError(_("Error decoding the JSON. Check the file content.")) from e
+			log.warning("JSON file is corrupt, loading empty data: %s", self.json_file_path)
+			raise JSONDecodeError(_("Error decoding the JSON. Check the file content."), doc='', pos=0)
 
 	def save_links(self):
 		"""

--- a/addon/globalPlugins/favoriteLinks/linkManager.py
+++ b/addon/globalPlugins/favoriteLinks/linkManager.py
@@ -80,7 +80,6 @@ class LinkManager:
 			self.data = {}
 			log.warning("JSON file is corrupt, loading empty data: %s", self.json_file_path)
 			self.save_links()
-			raise JSONDecodeError(_("Error decoding the JSON. Check the file content."), doc='', pos=0)
 
 	def save_links(self):
 		"""

--- a/addon/globalPlugins/favoriteLinks/linkManager.py
+++ b/addon/globalPlugins/favoriteLinks/linkManager.py
@@ -51,6 +51,21 @@ class LinkManager:
 		log.debug(f"[{ourAddon.name}] LinkManager inicializado. Caminho do JSON: '{self.json_file_path}'")
 		self.load_json()
 
+	@classmethod
+	def empty(cls):
+		"""
+		Creates a fully initialised but empty LinkManager without loading the
+		JSON file. Use this as a safe fallback when the normal constructor fails.
+
+		Returns:
+			LinkManager: An instance with an empty data dict and a valid
+				json_file_path.
+		"""
+		instance = cls.__new__(cls)
+		instance.json_file_path = json_config.get_current_json_path()
+		instance.data = {}
+		return instance
+
 	def load_json(self):
 		"""
 		It loads the JSON file data to the memory and ensures that the structure is clean.
@@ -78,7 +93,7 @@ class LinkManager:
 			self.save_links()
 		except JSONDecodeError:
 			self.data = {}
-			self.save_links()
+			log.warning("JSON file is corrupt, loading empty data: %s", self.json_file_path)
 			raise JSONDecodeError(_("Error decoding the JSON. Check the file content."), doc='', pos=0)
 
 	def save_links(self):

--- a/addon/globalPlugins/favoriteLinks/linkManager.py
+++ b/addon/globalPlugins/favoriteLinks/linkManager.py
@@ -91,10 +91,17 @@ class LinkManager:
 		except FileNotFoundError:
 			self.data = {}
 			self.save_links()
-		except JSONDecodeError:
+		except JSONDecodeError as e:
 			self.data = {}
-			log.warning("JSON file is corrupt, loading empty data: %s", self.json_file_path)
-			raise JSONDecodeError(_("Error decoding the JSON. Check the file content."), doc='', pos=0)
+			log.error("JSON file is corrupt, resetting to empty: %s", self.json_file_path)
+			try:
+				backup = self.json_file_path + ".corrupt"
+				os.rename(self.json_file_path, backup)
+				log.info("Corrupt JSON backed up to: %s", backup)
+			except OSError as backup_err:
+				log.warning("Could not back up corrupt JSON: %s", backup_err)
+			self.save_links()
+			raise RuntimeError(_("Error decoding the JSON. Check the file content.")) from e
 
 	def save_links(self):
 		"""

--- a/addon/globalPlugins/favoriteLinks/linkManager.py
+++ b/addon/globalPlugins/favoriteLinks/linkManager.py
@@ -23,6 +23,7 @@ from urllib.request import urlopen
 import addonHandler
 from api import getClipData
 from logHandler import log
+import NVDAState
 
 from .jsonConfig import json_config
 from .varsConfig import ourAddon, addonPath
@@ -76,16 +77,20 @@ class LinkManager:
 
 		except FileNotFoundError:
 			self.data = {}
-			self.save_links()
+			if NVDAState.shouldWriteToDisk():
+				self.save_links()
 		except JSONDecodeError:
 			self.data = {}
 			log.warning("JSON file is corrupt, loading empty data: %s", self.json_file_path)
-			self.save_links()
+			if NVDAState.shouldWriteToDisk():
+				self.save_links()
 
 	def save_links(self):
 		"""
 		Saves memory data to the JSON file.
 		"""
+		if not NVDAState.shouldWriteToDisk():
+			return
 		try:
 			with open(self.json_file_path, 'w', encoding='utf-8') as file:
 				json.dump(self.data, file, indent=4, ensure_ascii=False)

--- a/addon/globalPlugins/favoriteLinks/linkManager.py
+++ b/addon/globalPlugins/favoriteLinks/linkManager.py
@@ -51,21 +51,6 @@ class LinkManager:
 		log.debug(f"[{ourAddon.name}] LinkManager inicializado. Caminho do JSON: '{self.json_file_path}'")
 		self.load_json()
 
-	@classmethod
-	def empty(cls):
-		"""
-		Creates a fully initialised but empty LinkManager without loading the
-		JSON file. Use this as a safe fallback when the normal constructor fails.
-
-		Returns:
-			LinkManager: An instance with an empty data dict and a valid
-				json_file_path.
-		"""
-		instance = cls.__new__(cls)
-		instance.json_file_path = json_config.get_current_json_path()
-		instance.data = {}
-		return instance
-
 	def load_json(self):
 		"""
 		It loads the JSON file data to the memory and ensures that the structure is clean.
@@ -96,7 +81,7 @@ class LinkManager:
 			log.error("JSON file is corrupt, resetting to empty: %s", self.json_file_path)
 			try:
 				backup = self.json_file_path + ".corrupt"
-				os.rename(self.json_file_path, backup)
+				os.replace(self.json_file_path, backup)
 				log.info("Corrupt JSON backed up to: %s", backup)
 			except OSError as backup_err:
 				log.warning("Could not back up corrupt JSON: %s", backup_err)

--- a/addon/globalPlugins/favoriteLinks/searchLinks.py
+++ b/addon/globalPlugins/favoriteLinks/searchLinks.py
@@ -38,7 +38,7 @@ class SearchLinks(wx.Dialog):
 
 	Args:
 		parent (wx.Window): The parent window for this dialog.
-		link_manager (LinkManager): The shared LinkManager instance
+		link_manager (LinkManager): A `LinkManager` instance
 			containing all saved categories and links.
 	"""
 
@@ -47,12 +47,6 @@ class SearchLinks(wx.Dialog):
 
 		# Translators: Title of the search links dialog.
 		wx.Dialog.__init__(self, parent, title=_("Search links"))
-
-		if not self.link_manager.data:
-			# Translators: Spoken / shown when there are no saved categories to search.
-			ui.message(_("No categories found. Please add some links first."))
-			self.Destroy()
-			return
 
 		panel = wx.Panel(self)
 		boxSizer = wx.BoxSizer(wx.VERTICAL)
@@ -201,7 +195,8 @@ class SearchLinks(wx.Dialog):
 			return
 		title, url = result
 		try:
-			webbrowser.open(url)
+			if not webbrowser.open(url):
+				raise RuntimeError("webbrowser.open returned False")
 			# Translators: Announced when a found link is being opened.
 			ui.message(_("Opening {title}.").format(title=title))
 			self.EndModal(wx.ID_OK)
@@ -213,6 +208,7 @@ class SearchLinks(wx.Dialog):
 				caption=_("Error"),
 				style=wx.OK | wx.ICON_ERROR,
 			)
+			self.listResults.SetFocus()
 
 	def onCopyUrl(self, event):
 		"""

--- a/addon/globalPlugins/favoriteLinks/searchLinks.py
+++ b/addon/globalPlugins/favoriteLinks/searchLinks.py
@@ -202,7 +202,6 @@ class SearchLinks(wx.Dialog):
 		count = len(self.results)
 		# Translators: Label shown above the results list; {count} is the number of matches.
 		results_count_label = _("Results: {count} found.").format(count=count)
-		# Translators: Label shown above the results list; {count} is the number of matches.
 		self.resultsLabel.SetLabel(
 			results_count_label
 		)

--- a/addon/globalPlugins/favoriteLinks/searchLinks.py
+++ b/addon/globalPlugins/favoriteLinks/searchLinks.py
@@ -224,10 +224,12 @@ class SearchLinks(wx.Dialog):
 			self.listResults.SetFocus()
 			return
 		_title, url = result
-		if api.copyToClip(url):
+		try:
+			api.copyToClip(url)
 			# Translators: Announced when a URL from the search results is copied to the clipboard.
 			ui.message(_("URL copied to clipboard."))
-		else:
+		except Exception as e:
+			log.error("Error copying URL to clipboard: %s", e)
 			# Translators: Announced/shown when copying a URL to the clipboard fails.
 			ui.message(_("Failed to copy URL to clipboard."))
 

--- a/addon/globalPlugins/favoriteLinks/searchLinks.py
+++ b/addon/globalPlugins/favoriteLinks/searchLinks.py
@@ -23,9 +23,6 @@ import wx
 from gui import guiHelper, mainFrame, messageBox
 from logHandler import log
 
-from .linkManager import LinkManager
-
-# Initialize translation support
 addonHandler.initTranslation()
 
 
@@ -47,16 +44,17 @@ class SearchLinks(wx.Dialog):
 	def __init__(self, parent, link_manager):
 		self._link_manager = link_manager
 
-		if not self._link_manager.data:
-			# Translators: Spoken / shown when there are no saved categories to search.
-			ui.message(_("No categories found. Please add some links first."))
-			return
-
 		# Translators: Title of the search links dialog.
 		super(SearchLinks, self).__init__(
 			parent,
 			title=_("Search links")
 		)
+
+		if not self._link_manager.data:
+			# Translators: Spoken / shown when there are no saved categories to search.
+			ui.message(_("No categories found. Please add some links first."))
+			self.Destroy()
+			return
 
 		panel = wx.Panel(self)
 		boxSizer = wx.BoxSizer(wx.VERTICAL)
@@ -72,7 +70,7 @@ class SearchLinks(wx.Dialog):
 
 		# Search term field
 		self._txtSearch = sizerHelper.addLabeledControl(
-			_("Search word:"), wx.TextCtrl
+			_("Search word:"), wx.TextCtrl, style=wx.TE_PROCESS_ENTER
 		)
 		self._txtSearch.Bind(wx.EVT_TEXT_ENTER, self.onSearch)
 
@@ -122,12 +120,6 @@ class SearchLinks(wx.Dialog):
 		boxSizer.Add(buttonSizer.sizer, border=5, flag=wx.CENTER)
 		panel.SetSizerAndFit(boxSizer)
 		self.Fit()
-
-		mainFrame.prePopup()
-		self.CentreOnScreen()
-		self.ShowModal()
-		mainFrame.postPopup()
-		self.Destroy()
 
 	# ------------------------------------------------------------------
 	# Private helpers
@@ -222,9 +214,15 @@ class SearchLinks(wx.Dialog):
 			webbrowser.open(url)
 			# Translators: Announced when a found link is being opened.
 			ui.message(_("Opening {title}.").format(title=title))
+			self.EndModal(wx.ID_OK)
 		except Exception as e:
 			log.error("Error opening search result URL: %s", e)
-		self.EndModal(wx.ID_OK)
+			# Translators: Shown when a link cannot be opened in the browser.
+			self.show_message(
+				_("Unable to open the selected link. Please check your browser or the URL and try again."),
+				caption=_("Error"),
+				style=wx.OK | wx.ICON_ERROR,
+			)
 
 	def onCopyUrl(self, event):
 		"""
@@ -243,6 +241,9 @@ class SearchLinks(wx.Dialog):
 		if api.copyToClip(url):
 			# Translators: Announced when a URL from the search results is copied to the clipboard.
 			ui.message(_("URL copied to clipboard."))
+		else:
+			# Translators: Announced/shown when copying a URL to the clipboard fails.
+			ui.message(_("Failed to copy URL to clipboard."))
 
 	def onCancel(self, event):
 		"""

--- a/addon/globalPlugins/favoriteLinks/searchLinks.py
+++ b/addon/globalPlugins/favoriteLinks/searchLinks.py
@@ -309,7 +309,7 @@ class SearchLinks(wx.Dialog):
 		Args:
 			event (wx.Event): The key-down event on the results list.
 		"""
-		if event.GetKeyCode() == wx.WXK_RETURN:
+		if event.GetKeyCode() in (wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER):
 			self.onOpenResult(event)
 			return
 		event.Skip()

--- a/addon/globalPlugins/favoriteLinks/searchLinks.py
+++ b/addon/globalPlugins/favoriteLinks/searchLinks.py
@@ -20,9 +20,10 @@ import addonHandler
 import api
 import ui
 import wx
-from gui import guiHelper, mainFrame, messageBox
+from gui import guiHelper, messageBox
 from logHandler import log
 
+# Initialize translation support
 addonHandler.initTranslation()
 
 
@@ -42,15 +43,12 @@ class SearchLinks(wx.Dialog):
 	"""
 
 	def __init__(self, parent, link_manager):
-		self._link_manager = link_manager
+		self.link_manager = link_manager
 
 		# Translators: Title of the search links dialog.
-		super(SearchLinks, self).__init__(
-			parent,
-			title=_("Search links")
-		)
+		wx.Dialog.__init__(self, parent, title=_("Search links"))
 
-		if not self._link_manager.data:
+		if not self.link_manager.data:
 			# Translators: Spoken / shown when there are no saved categories to search.
 			ui.message(_("No categories found. Please add some links first."))
 			self.Destroy()
@@ -62,41 +60,43 @@ class SearchLinks(wx.Dialog):
 		buttonSizer = guiHelper.BoxSizerHelper(panel, wx.HORIZONTAL)
 
 		# Category selector
-		categories = list(self._link_manager.data.keys())
-		self._categoryChoice = sizerHelper.addLabeledControl(
+		categories = list(self.link_manager.data.keys())
+		self.categoryChoice = sizerHelper.addLabeledControl(
 			_("Select a category:"), wx.Choice, choices=categories
 		)
-		self._categoryChoice.SetSelection(0)
+		self.categoryChoice.SetSelection(0)
 
 		# Search term field
-		self._txtSearch = sizerHelper.addLabeledControl(
+		self.txtSearch = sizerHelper.addLabeledControl(
 			_("Search word:"), wx.TextCtrl, style=wx.TE_PROCESS_ENTER
 		)
-		self._txtSearch.Bind(wx.EVT_TEXT_ENTER, self.onSearch)
+		self.txtSearch.Bind(wx.EVT_TEXT_ENTER, self.onSearch)
 
 		# Search-by radio box
+		# Translators: Radio option to search links by their display name.
+		choice_name = _("Name")
+		# Translators: Radio option to search links by their URL.
+		choice_url = _("URL")
 		# Translators: Label for the radio group that selects what field to search.
-		self._searchBy = wx.RadioBox(
+		self.searchBy = wx.RadioBox(
 			panel,
 			label=_("Search by"),
-			# Translators: Radio option to search links by their display name.
-			# Translators: Radio option to search links by their URL.
-			choices=[_("Name"), _("URL")]
+			choices=[choice_name, choice_url]
 		)
-		sizerHelper.addItem(self._searchBy)
+		sizerHelper.addItem(self.searchBy)
 
 		# Results list (hidden until a search is performed)
 		# Translators: Label for the list that shows search results.
-		self._resultsLabel = wx.StaticText(panel, label="")
-		sizerHelper.addItem(self._resultsLabel)
-		self._listResults = wx.ListBox(panel, choices=[])
-		self._listResults.Bind(wx.EVT_LISTBOX_DCLICK, self.onOpenResult)
-		self._listResults.Bind(wx.EVT_KEY_DOWN, self.onResultsKeyPress)
-		sizerHelper.addItem(self._listResults)
+		self.resultsLabel = wx.StaticText(panel, label="")
+		sizerHelper.addItem(self.resultsLabel)
+		self.listResults = wx.ListBox(panel, choices=[])
+		self.listResults.Bind(wx.EVT_LISTBOX_DCLICK, self.onOpenResult)
+		self.listResults.Bind(wx.EVT_KEY_DOWN, self.onResultsKeyPress)
+		sizerHelper.addItem(self.listResults)
 
 		# Hide results section until a search has been run
-		self._resultsLabel.Hide()
-		self._listResults.Hide()
+		self.resultsLabel.Hide()
+		self.listResults.Hide()
 
 		# Buttons
 		search_button = wx.Button(panel, label=_("&Search"))
@@ -121,26 +121,16 @@ class SearchLinks(wx.Dialog):
 		panel.SetSizerAndFit(boxSizer)
 		self.Fit()
 
-	# ------------------------------------------------------------------
-	# Private helpers
-	# ------------------------------------------------------------------
 
 	def _get_selected_result(self):
 		"""
-		Returns the ``(title, url)`` pair for the currently selected result,
-		or ``None`` if nothing is selected.
-
-		Returns:
-			tuple or None: ``(title, url)`` of the selected result, or None.
+		Returns the (title, url) pair for the currently selected result,
+		or None if nothing is selected.
 		"""
-		index = self._listResults.GetSelection()
+		index = self.listResults.GetSelection()
 		if index == wx.NOT_FOUND:
 			return None
-		return self._results[index]
-
-	# ------------------------------------------------------------------
-	# Event handlers
-	# ------------------------------------------------------------------
+		return self.results[index]
 
 	def onSearch(self, event):
 		"""
@@ -150,48 +140,48 @@ class SearchLinks(wx.Dialog):
 			event (wx.Event): The event triggered by the Search button or
 				pressing Enter in the search field.
 		"""
-		search_word = self._txtSearch.GetValue().strip()
+		search_word = self.txtSearch.GetValue().strip()
 		if not search_word:
 			# Translators: Spoken when the user activates Search with an empty field.
 			self.show_message(_("Please enter a search word."))
-			self._txtSearch.SetFocus()
+			self.txtSearch.SetFocus()
 			return
 
-		category = self._categoryChoice.GetStringSelection()
-		links = self._link_manager.data.get(category, [])
-		search_by_url = self._searchBy.GetSelection() == 1
+		category = self.categoryChoice.GetStringSelection()
+		links = self.link_manager.data.get(category, [])
+		search_by_url = self.searchBy.GetSelection() == 1
 
-		self._results = []
+		self.results = []
 		for title, url in links:
 			haystack = url if search_by_url else title
 			if search_word.lower() in haystack.lower():
-				self._results.append((title, url))
+				self.results.append((title, url))
 
-		self._listResults.Clear()
+		self.listResults.Clear()
 
-		if not self._results:
-			self._resultsLabel.Hide()
-			self._listResults.Hide()
+		if not self.results:
+			self.resultsLabel.Hide()
+			self.listResults.Hide()
 			self.Layout()
 			self.Fit()
 			# Translators: Shown when the search produces no matches.
 			self.show_message(_("No results found."), _("Search"))
 			return
 
-		for title, url in self._results:
-			self._listResults.Append("{title}  —  {url}".format(title=title, url=url))
+		for title, url in self.results:
+			self.listResults.Append("{title}  —  {url}".format(title=title, url=url))
 
-		count = len(self._results)
+		count = len(self.results)
 		# Translators: Label shown above the results list; {count} is the number of matches.
-		self._resultsLabel.SetLabel(
+		self.resultsLabel.SetLabel(
 			_("Results: {count} found.").format(count=count)
 		)
-		self._resultsLabel.Show()
-		self._listResults.Show()
+		self.resultsLabel.Show()
+		self.listResults.Show()
 		self.Layout()
 		self.Fit()
-		self._listResults.SetSelection(0)
-		self._listResults.SetFocus()
+		self.listResults.SetSelection(0)
+		self.listResults.SetFocus()
 		# Translators: Announced when results appear; {count} is the number of matches.
 		ui.message(_("{count} results found.").format(count=count))
 
@@ -207,7 +197,7 @@ class SearchLinks(wx.Dialog):
 		if result is None:
 			# Translators: Spoken when the user tries to open a result without selecting one.
 			self.show_message(_("No result selected to open!"))
-			self._listResults.SetFocus()
+			self.listResults.SetFocus()
 			return
 		title, url = result
 		try:
@@ -235,7 +225,7 @@ class SearchLinks(wx.Dialog):
 		if result is None:
 			# Translators: Spoken when the user tries to copy a URL without selecting a result.
 			self.show_message(_("No result selected to copy!"))
-			self._listResults.SetFocus()
+			self.listResults.SetFocus()
 			return
 		_title, url = result
 		if api.copyToClip(url):
@@ -281,12 +271,6 @@ class SearchLinks(wx.Dialog):
 
 	def show_message(self, message, caption=_("Attention"), style=wx.OK | wx.ICON_INFORMATION):
 		"""
-		Displays a message to the user in a dialog box.
-
-		Args:
-			message (str): The message to be displayed.
-			caption (str, optional): The dialog title. Defaults to "Attention".
-			style (int, optional): The dialog style flags. Defaults to
-				wx.OK | wx.ICON_INFORMATION.
+		Displays a message to the user.
 		"""
 		messageBox(message, caption, style)

--- a/addon/globalPlugins/favoriteLinks/searchLinks.py
+++ b/addon/globalPlugins/favoriteLinks/searchLinks.py
@@ -1,0 +1,291 @@
+# -*- coding: UTF-8 -*-
+
+"""
+Author: Edilberto Fonseca <edilberto.fonseca@outlook.com>
+Copyright: (C) 2025 Edilberto Fonseca
+
+This file is covered by the GNU General Public License.
+See the file COPYING for more details or visit:
+https://www.gnu.org/licenses/gpl-2.0.html
+
+Feature inspired by the Link Manager add-on by Abdallah Hader:
+https://github.com/abdallah-hader/linkManager
+
+Created on: 08/03/2025
+"""
+
+import webbrowser
+
+import addonHandler
+import api
+import ui
+import wx
+from gui import guiHelper, mainFrame, messageBox
+from logHandler import log
+
+from .linkManager import LinkManager
+
+# Initialize translation support
+addonHandler.initTranslation()
+
+
+class SearchLinks(wx.Dialog):
+	"""
+	Dialog that allows users to search for saved links by title or URL.
+
+	The user selects a category, types a search term, chooses whether to
+	search by link name or by URL, and sees the matching results in a list.
+	From the results list the user can open the selected link or copy its
+	URL to the clipboard.
+
+	Args:
+		parent (wx.Window): The parent window for this dialog.
+		link_manager (LinkManager): The shared LinkManager instance
+			containing all saved categories and links.
+	"""
+
+	def __init__(self, parent, link_manager):
+		self._link_manager = link_manager
+
+		if not self._link_manager.data:
+			# Translators: Spoken / shown when there are no saved categories to search.
+			ui.message(_("No categories found. Please add some links first."))
+			return
+
+		# Translators: Title of the search links dialog.
+		super(SearchLinks, self).__init__(
+			parent,
+			title=_("Search links")
+		)
+
+		panel = wx.Panel(self)
+		boxSizer = wx.BoxSizer(wx.VERTICAL)
+		sizerHelper = guiHelper.BoxSizerHelper(panel, wx.VERTICAL)
+		buttonSizer = guiHelper.BoxSizerHelper(panel, wx.HORIZONTAL)
+
+		# Category selector
+		categories = list(self._link_manager.data.keys())
+		self._categoryChoice = sizerHelper.addLabeledControl(
+			_("Select a category:"), wx.Choice, choices=categories
+		)
+		self._categoryChoice.SetSelection(0)
+
+		# Search term field
+		self._txtSearch = sizerHelper.addLabeledControl(
+			_("Search word:"), wx.TextCtrl
+		)
+		self._txtSearch.Bind(wx.EVT_TEXT_ENTER, self.onSearch)
+
+		# Search-by radio box
+		# Translators: Label for the radio group that selects what field to search.
+		self._searchBy = wx.RadioBox(
+			panel,
+			label=_("Search by"),
+			# Translators: Radio option to search links by their display name.
+			# Translators: Radio option to search links by their URL.
+			choices=[_("Name"), _("URL")]
+		)
+		sizerHelper.addItem(self._searchBy)
+
+		# Results list (hidden until a search is performed)
+		# Translators: Label for the list that shows search results.
+		self._resultsLabel = wx.StaticText(panel, label="")
+		sizerHelper.addItem(self._resultsLabel)
+		self._listResults = wx.ListBox(panel, choices=[])
+		self._listResults.Bind(wx.EVT_LISTBOX_DCLICK, self.onOpenResult)
+		self._listResults.Bind(wx.EVT_KEY_DOWN, self.onResultsKeyPress)
+		sizerHelper.addItem(self._listResults)
+
+		# Hide results section until a search has been run
+		self._resultsLabel.Hide()
+		self._listResults.Hide()
+
+		# Buttons
+		search_button = wx.Button(panel, label=_("&Search"))
+		search_button.SetDefault()
+		open_button = wx.Button(panel, label=_("&Open"))
+		copy_button = wx.Button(panel, label=_("&Copy URL"))
+		cancel_button = wx.Button(panel, wx.ID_CANCEL, _("&Cancel"))
+
+		buttonSizer.addItem(search_button)
+		buttonSizer.addItem(open_button)
+		buttonSizer.addItem(copy_button)
+		buttonSizer.addItem(cancel_button)
+
+		self.Bind(wx.EVT_BUTTON, self.onSearch, search_button)
+		self.Bind(wx.EVT_BUTTON, self.onOpenResult, open_button)
+		self.Bind(wx.EVT_BUTTON, self.onCopyUrl, copy_button)
+		self.Bind(wx.EVT_BUTTON, self.onCancel, cancel_button)
+		self.Bind(wx.EVT_CHAR_HOOK, self.onKeyPress)
+
+		boxSizer.Add(sizerHelper.sizer, border=10, flag=wx.ALL | wx.EXPAND)
+		boxSizer.Add(buttonSizer.sizer, border=5, flag=wx.CENTER)
+		panel.SetSizerAndFit(boxSizer)
+		self.Fit()
+
+		mainFrame.prePopup()
+		self.CentreOnScreen()
+		self.ShowModal()
+		mainFrame.postPopup()
+		self.Destroy()
+
+	# ------------------------------------------------------------------
+	# Private helpers
+	# ------------------------------------------------------------------
+
+	def _get_selected_result(self):
+		"""
+		Returns the ``(title, url)`` pair for the currently selected result,
+		or ``None`` if nothing is selected.
+
+		Returns:
+			tuple or None: ``(title, url)`` of the selected result, or None.
+		"""
+		index = self._listResults.GetSelection()
+		if index == wx.NOT_FOUND:
+			return None
+		return self._results[index]
+
+	# ------------------------------------------------------------------
+	# Event handlers
+	# ------------------------------------------------------------------
+
+	def onSearch(self, event):
+		"""
+		Executes the search and populates the results list.
+
+		Args:
+			event (wx.Event): The event triggered by the Search button or
+				pressing Enter in the search field.
+		"""
+		search_word = self._txtSearch.GetValue().strip()
+		if not search_word:
+			# Translators: Spoken when the user activates Search with an empty field.
+			self.show_message(_("Please enter a search word."))
+			self._txtSearch.SetFocus()
+			return
+
+		category = self._categoryChoice.GetStringSelection()
+		links = self._link_manager.data.get(category, [])
+		search_by_url = self._searchBy.GetSelection() == 1
+
+		self._results = []
+		for title, url in links:
+			haystack = url if search_by_url else title
+			if search_word.lower() in haystack.lower():
+				self._results.append((title, url))
+
+		self._listResults.Clear()
+
+		if not self._results:
+			self._resultsLabel.Hide()
+			self._listResults.Hide()
+			self.Layout()
+			self.Fit()
+			# Translators: Shown when the search produces no matches.
+			self.show_message(_("No results found."), _("Search"))
+			return
+
+		for title, url in self._results:
+			self._listResults.Append("{title}  —  {url}".format(title=title, url=url))
+
+		count = len(self._results)
+		# Translators: Label shown above the results list; {count} is the number of matches.
+		self._resultsLabel.SetLabel(
+			_("Results: {count} found.").format(count=count)
+		)
+		self._resultsLabel.Show()
+		self._listResults.Show()
+		self.Layout()
+		self.Fit()
+		self._listResults.SetSelection(0)
+		self._listResults.SetFocus()
+		# Translators: Announced when results appear; {count} is the number of matches.
+		ui.message(_("{count} results found.").format(count=count))
+
+	def onOpenResult(self, event):
+		"""
+		Opens the selected search result in the default browser.
+
+		Args:
+			event (wx.Event): The event triggered by the Open button or a
+				double-click / Enter on the results list.
+		"""
+		result = self._get_selected_result()
+		if result is None:
+			# Translators: Spoken when the user tries to open a result without selecting one.
+			self.show_message(_("No result selected to open!"))
+			self._listResults.SetFocus()
+			return
+		title, url = result
+		try:
+			webbrowser.open(url)
+			# Translators: Announced when a found link is being opened.
+			ui.message(_("Opening {title}.").format(title=title))
+		except Exception as e:
+			log.error("Error opening search result URL: %s", e)
+		self.EndModal(wx.ID_OK)
+
+	def onCopyUrl(self, event):
+		"""
+		Copies the URL of the selected search result to the system clipboard.
+
+		Args:
+			event (wx.Event): The event triggered by the Copy URL button.
+		"""
+		result = self._get_selected_result()
+		if result is None:
+			# Translators: Spoken when the user tries to copy a URL without selecting a result.
+			self.show_message(_("No result selected to copy!"))
+			self._listResults.SetFocus()
+			return
+		_title, url = result
+		if api.copyToClip(url):
+			# Translators: Announced when a URL from the search results is copied to the clipboard.
+			ui.message(_("URL copied to clipboard."))
+
+	def onCancel(self, event):
+		"""
+		Closes the dialog without taking any action.
+
+		Args:
+			event (wx.Event): The cancel event.
+		"""
+		self.EndModal(wx.ID_CANCEL)
+
+	def onResultsKeyPress(self, event):
+		"""
+		Handles key presses inside the results list:
+		Enter opens the selected result.
+
+		Args:
+			event (wx.Event): The key-down event on the results list.
+		"""
+		if event.GetKeyCode() == wx.WXK_RETURN:
+			self.onOpenResult(event)
+			return
+		event.Skip()
+
+	def onKeyPress(self, event):
+		"""
+		Handles dialog-level key presses: Escape closes the dialog.
+
+		Args:
+			event (wx.Event): The key-hook event.
+		"""
+		if event.GetKeyCode() == wx.WXK_ESCAPE:
+			self.onCancel(event)
+			return
+		event.Skip()
+
+	def show_message(self, message, caption=_("Attention"), style=wx.OK | wx.ICON_INFORMATION):
+		"""
+		Displays a message to the user in a dialog box.
+
+		Args:
+			message (str): The message to be displayed.
+			caption (str, optional): The dialog title. Defaults to "Attention".
+			style (int, optional): The dialog style flags. Defaults to
+				wx.OK | wx.ICON_INFORMATION.
+		"""
+		messageBox(message, caption, style)

--- a/addon/globalPlugins/favoriteLinks/searchLinks.py
+++ b/addon/globalPlugins/favoriteLinks/searchLinks.py
@@ -15,7 +15,6 @@ Created on: 08/03/2025
 """
 
 import webbrowser
-
 import addonHandler
 import api
 import ui
@@ -56,14 +55,22 @@ class SearchLinks(wx.Dialog):
 		# Category selector — first item is a catch-all for global search
 		# Translators: First option in the category dropdown; searches across all categories.
 		all_categories_label = _("(All categories)")
-		categories = [all_categories_label] + list(self.link_manager.data.keys())
+		original_categories = list(self.link_manager.data.keys())
+		display_all_label = all_categories_label
+		suffix = 1
+		while display_all_label in original_categories:
+			display_all_label = "{} ({})".format(all_categories_label, suffix)
+			suffix += 1
+		categories = [display_all_label] + original_categories
 		self.categoryChoice = sizerHelper.addLabeledControl(
+			# Translators: Label for the category dropdown in the search dialog.
 			_("Select a category:"), wx.Choice, choices=categories
 		)
 		self.categoryChoice.SetSelection(0)
 
 		# Search term field
 		self.txtSearch = sizerHelper.addLabeledControl(
+			# Translators: Label for the search text input field.
 			_("Search word:"), wx.TextCtrl, style=wx.TE_PROCESS_ENTER
 		)
 		self.txtSearch.Bind(wx.EVT_TEXT_ENTER, self.onSearch)
@@ -74,9 +81,11 @@ class SearchLinks(wx.Dialog):
 		# Translators: Radio option to search links by their URL.
 		choice_url = _("URL")
 		# Translators: Label for the radio group that selects what field to search.
+		search_by_label = _("Search by")
+		# Translators: Label for the radio group that selects what field to search.
 		self.searchBy = wx.RadioBox(
 			panel,
-			label=_("Search by"),
+			label=search_by_label,
 			choices=[choice_name, choice_url]
 		)
 		sizerHelper.addItem(self.searchBy)
@@ -95,20 +104,26 @@ class SearchLinks(wx.Dialog):
 		self.listResults.Hide()
 
 		# Buttons
+		# Translators: Label for the button that runs the search.
 		search_button = wx.Button(panel, label=_("&Search"))
 		search_button.SetDefault()
-		open_button = wx.Button(panel, label=_("&Open"))
-		copy_button = wx.Button(panel, label=_("&Copy URL"))
+		# Translators: Label for the button that opens the selected URL.
+		self._openButton = wx.Button(panel, label=_("&Open"))
+		# Translators: Label for the button that copies the selected URL.
+		self._copyButton = wx.Button(panel, label=_("&Copy URL"))
+		# Translators: Label for the button that closes the dialog.
 		cancel_button = wx.Button(panel, wx.ID_CANCEL, _("&Cancel"))
+		self._openButton.Disable()
+		self._copyButton.Disable()
 
 		buttonSizer.addItem(search_button)
-		buttonSizer.addItem(open_button)
-		buttonSizer.addItem(copy_button)
+		buttonSizer.addItem(self._openButton)
+		buttonSizer.addItem(self._copyButton)
 		buttonSizer.addItem(cancel_button)
 
 		self.Bind(wx.EVT_BUTTON, self.onSearch, search_button)
-		self.Bind(wx.EVT_BUTTON, self.onOpenResult, open_button)
-		self.Bind(wx.EVT_BUTTON, self.onCopyUrl, copy_button)
+		self.Bind(wx.EVT_BUTTON, self.onOpenResult, self._openButton)
+		self.Bind(wx.EVT_BUTTON, self.onCopyUrl, self._copyButton)
 		self.Bind(wx.EVT_BUTTON, self.onCancel, cancel_button)
 		self.Bind(wx.EVT_CHAR_HOOK, self.onKeyPress)
 
@@ -127,6 +142,12 @@ class SearchLinks(wx.Dialog):
 		if index == wx.NOT_FOUND:
 			return None
 		return self.results[index]
+
+	def _update_action_buttons(self):
+		"""Enable or disable Open/Copy based on whether results are visible."""
+		has_results = self.listResults.IsShown() and self.listResults.GetCount() > 0
+		self._openButton.Enable(has_results)
+		self._copyButton.Enable(has_results)
 
 	def onSearch(self, event):
 		"""
@@ -168,7 +189,11 @@ class SearchLinks(wx.Dialog):
 			self.Layout()
 			self.Fit()
 			# Translators: Shown when the search produces no matches.
-			self.show_message(_("No results found."), _("Search"))
+			no_results_message = _("No results found.")
+			# Translators: Caption for no-results messages in the search dialog.
+			search_caption = _("Search")
+			self.show_message(no_results_message, search_caption)
+			self._update_action_buttons()
 			return
 
 		for title, url in self.results:
@@ -176,8 +201,10 @@ class SearchLinks(wx.Dialog):
 
 		count = len(self.results)
 		# Translators: Label shown above the results list; {count} is the number of matches.
+		results_count_label = _("Results: {count} found.").format(count=count)
+		# Translators: Label shown above the results list; {count} is the number of matches.
 		self.resultsLabel.SetLabel(
-			_("Results: {count} found.").format(count=count)
+			results_count_label
 		)
 		self.resultsLabel.Show()
 		self.listResults.Show()
@@ -185,6 +212,7 @@ class SearchLinks(wx.Dialog):
 		self.Fit()
 		self.listResults.SetSelection(0)
 		self.listResults.SetFocus()
+		self._update_action_buttons()
 		# Translators: Announced when results appear; {count} is the number of matches.
 		ui.message(_("{count} results found.").format(count=count))
 
@@ -200,10 +228,22 @@ class SearchLinks(wx.Dialog):
 		if result is None:
 			# Translators: Spoken when the user tries to open a result without selecting one.
 			self.show_message(_("No result selected to open!"))
-			self.listResults.SetFocus()
+			self.txtSearch.SetFocus()
 			return
 		title, url = result
 		try:
+			if not self.link_manager.is_internet_connected():
+				# Translators: Shown when user tries to open a link but there is no internet connection.
+				no_connection_message = _("No active internet connection!")
+				# Translators: Caption for no-connection error messages.
+				no_connection_caption = _("Error")
+				self.show_message(
+					no_connection_message,
+					no_connection_caption,
+					wx.OK | wx.ICON_ERROR
+				)
+				self.listResults.SetFocus()
+				return
 			if not webbrowser.open(url):
 				raise RuntimeError("webbrowser.open returned False")
 			# Translators: Announced when a found link is being opened.
@@ -212,9 +252,12 @@ class SearchLinks(wx.Dialog):
 		except Exception as e:
 			log.error("Error opening search result URL: %s", e)
 			# Translators: Shown when a link cannot be opened in the browser.
+			open_error_message = _("Unable to open the selected link. Please check your browser or the URL and try again.")
+			# Translators: Caption for browser opening failures.
+			error_caption = _("Error")
 			self.show_message(
-				_("Unable to open the selected link. Please check your browser or the URL and try again."),
-				caption=_("Error"),
+				open_error_message,
+				caption=error_caption,
 				style=wx.OK | wx.ICON_ERROR,
 			)
 			self.listResults.SetFocus()
@@ -230,7 +273,7 @@ class SearchLinks(wx.Dialog):
 		if result is None:
 			# Translators: Spoken when the user tries to copy a URL without selecting a result.
 			self.show_message(_("No result selected to copy!"))
-			self.listResults.SetFocus()
+			self.txtSearch.SetFocus()
 			return
 		_title, url = result
 		try:
@@ -276,8 +319,11 @@ class SearchLinks(wx.Dialog):
 			return
 		event.Skip()
 
-	def show_message(self, message, caption=_("Attention"), style=wx.OK | wx.ICON_INFORMATION):
+	def show_message(self, message, caption=None, style=wx.OK | wx.ICON_INFORMATION):
 		"""
 		Displays a message to the user.
 		"""
+		if caption is None:
+			# Translators: Default caption for message boxes in the search dialog.
+			caption = _("Search Links")
 		messageBox(message, caption, style)

--- a/addon/globalPlugins/favoriteLinks/searchLinks.py
+++ b/addon/globalPlugins/favoriteLinks/searchLinks.py
@@ -15,6 +15,7 @@ Created on: 08/03/2025
 """
 
 import webbrowser
+
 import addonHandler
 import api
 import ui
@@ -83,7 +84,6 @@ class SearchLinks(wx.Dialog):
 		choice_url = _("URL")
 		# Translators: Label for the radio group that selects what field to search.
 		search_by_label = _("Search by")
-		# Translators: Label for the radio group that selects what field to search.
 		self.searchBy = wx.RadioBox(
 			panel,
 			label=search_by_label,

--- a/addon/globalPlugins/favoriteLinks/searchLinks.py
+++ b/addon/globalPlugins/favoriteLinks/searchLinks.py
@@ -178,9 +178,12 @@ class SearchLinks(wx.Dialog):
 
 		self.results = []
 		for title, url in links:
-			haystack = url if search_by_url else title
+			# Coerce to str to guard against non-string values in hand-edited JSON.
+			title_str = str(title) if title is not None else ""
+			url_str = str(url) if url is not None else ""
+			haystack = url_str if search_by_url else title_str
 			if search_word.lower() in haystack.lower():
-				self.results.append((title, url))
+				self.results.append((title_str, url_str))
 
 		self.listResults.Clear()
 

--- a/addon/globalPlugins/favoriteLinks/searchLinks.py
+++ b/addon/globalPlugins/favoriteLinks/searchLinks.py
@@ -43,6 +43,7 @@ class SearchLinks(wx.Dialog):
 
 	def __init__(self, parent, link_manager):
 		self.link_manager = link_manager
+		self.results = []
 
 		# Translators: Title of the search links dialog.
 		wx.Dialog.__init__(self, parent, title=_("Search links"))
@@ -227,7 +228,10 @@ class SearchLinks(wx.Dialog):
 		if result is None:
 			# Translators: Spoken when the user tries to open a result without selecting one.
 			self.show_message(_("No result selected to open!"))
-			self.txtSearch.SetFocus()
+			if self.listResults.IsShown():
+				self.listResults.SetFocus()
+			else:
+				self.txtSearch.SetFocus()
 			return
 		title, url = result
 		if not self.link_manager.is_internet_connected():
@@ -238,7 +242,7 @@ class SearchLinks(wx.Dialog):
 				_("Error"),
 				wx.OK | wx.ICON_ERROR
 			)
-			self.txtSearch.SetFocus()
+			self.listResults.SetFocus()
 			return
 		try:
 			if not webbrowser.open(url):
@@ -270,7 +274,10 @@ class SearchLinks(wx.Dialog):
 		if result is None:
 			# Translators: Spoken when the user tries to copy a URL without selecting a result.
 			self.show_message(_("No result selected to copy!"))
-			self.txtSearch.SetFocus()
+			if self.listResults.IsShown():
+				self.listResults.SetFocus()
+			else:
+				self.txtSearch.SetFocus()
 			return
 		_title, url = result
 		try:

--- a/addon/globalPlugins/favoriteLinks/searchLinks.py
+++ b/addon/globalPlugins/favoriteLinks/searchLinks.py
@@ -53,8 +53,10 @@ class SearchLinks(wx.Dialog):
 		sizerHelper = guiHelper.BoxSizerHelper(panel, wx.VERTICAL)
 		buttonSizer = guiHelper.BoxSizerHelper(panel, wx.HORIZONTAL)
 
-		# Category selector
-		categories = list(self.link_manager.data.keys())
+		# Category selector — first item is a catch-all for global search
+		# Translators: First option in the category dropdown; searches across all categories.
+		all_categories_label = _("(All categories)")
+		categories = [all_categories_label] + list(self.link_manager.data.keys())
 		self.categoryChoice = sizerHelper.addLabeledControl(
 			_("Select a category:"), wx.Choice, choices=categories
 		)
@@ -141,8 +143,15 @@ class SearchLinks(wx.Dialog):
 			self.txtSearch.SetFocus()
 			return
 
-		category = self.categoryChoice.GetStringSelection()
-		links = self.link_manager.data.get(category, [])
+		category_idx = self.categoryChoice.GetSelection()
+		if category_idx == 0:
+			# "All categories" selected — gather links from every category
+			links = []
+			for cat_links in self.link_manager.data.values():
+				links.extend(cat_links)
+		else:
+			category = self.categoryChoice.GetStringSelection()
+			links = self.link_manager.data.get(category, [])
 		search_by_url = self.searchBy.GetSelection() == 1
 
 		self.results = []

--- a/addon/globalPlugins/favoriteLinks/searchLinks.py
+++ b/addon/globalPlugins/favoriteLinks/searchLinks.py
@@ -231,19 +231,17 @@ class SearchLinks(wx.Dialog):
 			self.txtSearch.SetFocus()
 			return
 		title, url = result
+		if not self.link_manager.is_internet_connected():
+			# Translators: Shown when the user tries to open a link with no internet connection.
+			self.show_message(
+				_("No active internet connection!"),
+				# Translators: Caption for the no-internet error dialog in search.
+				_("Error"),
+				wx.OK | wx.ICON_ERROR
+			)
+			self.txtSearch.SetFocus()
+			return
 		try:
-			if not self.link_manager.is_internet_connected():
-				# Translators: Shown when user tries to open a link but there is no internet connection.
-				no_connection_message = _("No active internet connection!")
-				# Translators: Caption for no-connection error messages.
-				no_connection_caption = _("Error")
-				self.show_message(
-					no_connection_message,
-					no_connection_caption,
-					wx.OK | wx.ICON_ERROR
-				)
-				self.listResults.SetFocus()
-				return
 			if not webbrowser.open(url):
 				raise RuntimeError("webbrowser.open returned False")
 			# Translators: Announced when a found link is being opened.


### PR DESCRIPTION
Adds a new keyboard shortcut (NVDA+Shift+G) to search through saved links.

**Note:** This branch builds on feature/open-url-from-clipboard. Merging the clipboard PR first is recommended.

Features:
- Select a specific category or '(All categories)' to search across every saved link
- Type a keyword and press Enter or click Search to filter results
- Search by link name or URL using the radio selector
- Open the selected link in the browser
- Copy the selected URL to the clipboard (try/except, not boolean check)
- Keyboard-accessible results list

Error handling:
- Distinct message for file load failure vs genuinely empty data
- Corrupt JSON backed up atomically via os.replace before reset; original exception preserved as cause
- Dialog creation wrapped in try/except; postPopup always called via try/finally