### PR TITLE
fix(edit-links): fix editing of saved links

### DIFF
--- a/addon/globalPlugins/favoriteLinks/configPanel.py
+++ b/addon/globalPlugins/favoriteLinks/configPanel.py
@@ -101,7 +101,7 @@ class FavoriteLinksSettingsPanel(SettingsPanel):
 				initial_dir,
 				initial_file,
 				wildcard=_("JSON files (*.json)|*.json"),
-				style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT # Add overwrite prompt
+				style=wx.FD_SAVE
 			)
 
 			if dlg.ShowModal() == wx.ID_OK:

--- a/addon/globalPlugins/favoriteLinks/editLinks.py
+++ b/addon/globalPlugins/favoriteLinks/editLinks.py
@@ -98,7 +98,7 @@ class EditLinks(wx.Dialog):
 			self.showMessage(_("All fields are required"), _("Error"), wx.OK | wx.ICON_ERROR)
 			return
 
-		if not self.linkManager.is_valid_url(newURL):
+		if not self.linkManager.isValidURL(newURL):
 			# translators: Error message displayed when the user enters an invalid URL.
 			self.showMessage(_("Invalid URL"), _("Error"), wx.OK | wx.ICON_ERROR)
 			return

--- a/addon/globalPlugins/favoriteLinks/main.py
+++ b/addon/globalPlugins/favoriteLinks/main.py
@@ -434,6 +434,8 @@ class FavoriteLinks(wx.Dialog):
 				self.linkManager.addLinkToCategory(category, title, url)
 				# translators: Message displayed when a link is added
 				self.showMessage(_("Link added successfully!"), _("Attention"))
+
+				# Updates the selected category to be the one where the link was added, so that it is restored after updating the interface.
 				self.selectedCategory = category
 
 				# Always updates the UI
@@ -495,7 +497,12 @@ class FavoriteLinks(wx.Dialog):
 					self.linkManager.editLinkInCategory(oldCategory, oldTitle, new_title, new_url)
 				# translators: Message displayed when a link is edited successfully
 				self.showMessage(_("Link edited successfully!"), _("Attention"))
+
+				# Updates the selected category
 				self.selectedCategory = new_category  # Sets the category to be restored
+
+				# Updates the interface
+				self.updateAllUI()
 
 			except (ValueError, KeyError) as e:
 				# translators: Message displayed when a link cannot be edited

--- a/buildVars.py
+++ b/buildVars.py
@@ -25,10 +25,10 @@ addon_info = AddonInfo(
 
 Shortcut Windows+Alt+K."""),
 	# version
-	addon_version="2025.10.0",
+	addon_version="2025.10.1",
 	# Brief changelog for this version
 	# Translators: what's new content for the add-on version to be shown in the add-on store
-	addon_changelog=_("""Adds new functionality to import saved links in HTML from your browsers."""),
+	addon_changelog=_("""Fixed issue preventing editing of saved links."""),
 	# Author(s)
 	addon_author="Edilberto Fonseca <edilberto.fonseca@outlook.com>",
 	# URL for the add-on documentation support

--- a/changelog.md
+++ b/changelog.md
@@ -1,16 +1,4 @@
 # Changelog
 
-## New Features
-
-- Added link search dialog by URL or title.
-- Implemented navigation by categories and links directly via the keyboard, without having to open the add-on interface.
-- Support for opening links from the clipboard, including detection of multiple URLs.
-- Added URL reading feature after the link name during keyboard navigation, which can be activated or deactivated.
-- Improvements to the HTML bookmark import interface, with a default “Imported Bookmarks” category and prevention of duplicates.
-
-### Fixes and Improvements
-
-- Correction of errors when opening links without an internet connection.
-- Adjustments to the persistence of navigation data between sessions.
-- Improved capture and handling of exceptions when opening URLs and copying to the clipboard.
-- Minor layout and interface message fixes in dialogs and results lists.
+- Fixes an issue that prevented editing previously saved links.
+- Removes overwrite prompt from JSON save file dialog.


### PR DESCRIPTION
- Fixes an issue that prevented editing previously saved links.
- Removes overwrite prompt from JSON save file dialog.